### PR TITLE
Fix indentation of file tree in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,25 @@ A Tour of the Repo
 ```
 path/to/twizzler
     cmake -- files for cmake build system
-	docs -- documentation files
-	ports -- files for patching and building ported software
-	src
-	  bin -- sources for twizzler programs
-	  boot -- files for booting twizzler
-	  drivers -- drivers for twizzler
-	  kernel -- twizzler kernel sources
-	    arch -- architecture-specific code
-		core -- main kernel source, non-system specific
-		include -- kernel-specific include files
-		lib -- kernel library files
-		machine -- platform-specific code
-	  lib -- sources for twizzler libraries
-	  playground -- testing area, write your hello world program in here :)
-	  share -- files that get installed in /usr/share in the sysroot
-	tools
-	  libtom* -- libraries for both kernel and userspace for crypto and math
-	  llvm-project -- LLVM and clang sources, used to build the toolchain
-	  utils -- utilities for compiling twizzler stuff on unix
+    docs -- documentation files
+    ports -- files for patching and building ported software
+    src
+        bin -- sources for twizzler programs
+        boot -- files for booting twizzler
+        drivers -- drivers for twizzler
+        kernel -- twizzler kernel sources
+            arch -- architecture-specific code
+                core -- main kernel source, non-system specific
+                include -- kernel-specific include files
+                lib -- kernel library files
+                machine -- platform-specific code
+        lib -- sources for twizzler libraries
+        playground -- testing area, write your hello world program in here :)
+        share -- files that get installed in /usr/share in the sysroot
+    tools
+        libtom* -- libraries for both kernel and userspace for crypto and math
+        llvm-project -- LLVM and clang sources, used to build the toolchain
+        utils -- utilities for compiling twizzler stuff on unix
 ```
 Building
 --------


### PR DESCRIPTION
The file tree used a mixture of tabs and spaces which resulted in the
tree giving the impression all code was in the 'cmake' directory when
the README was viewed using GitHub's Markdown viewer. Now, spaces are
used for consistency.